### PR TITLE
Bugfix css

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -86,6 +86,7 @@ p, h2{
   border: 2px solid $xmas-brown;
   border-radius: 50px;
   padding: 16px 26px;
+  display: inline-block;
 
 
  i {


### PR DESCRIPTION
ボタンのdisplayをinline-blockにするとレイアウトが整います。